### PR TITLE
ENH: replace re module by regex module in run-clang-tidy script

### DIFF
--- a/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tidy/tool/run-clang-tidy.py
@@ -39,7 +39,7 @@ import json
 import multiprocessing
 import os
 import Queue
-import re
+import regex as re
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
It allows to avoid limitation of 100 groups for regular expressions that could e
faced running the script against large code base. There is a discussion about
this limitation in re module on stackoverflow:

http://stackoverflow.com/questions/478458/python-regular-expressions-with-more-than-100-groups
