### PR TITLE
Replaced UserNullMacros with NullMacros in modernize-use-nullptr check docs

### DIFF
--- a/docs/clang-tidy/checks/modernize-use-nullptr.rst
+++ b/docs/clang-tidy/checks/modernize-use-nullptr.rst
@@ -39,7 +39,7 @@ transforms to:
 Options
 -------
 
-.. option:: UserNullMacros
+.. option:: NullMacros
 
    Comma-separated list of macro names that will be transformed along with
    ``NULL``. By default this check will only replace the ``NULL`` macro and will
@@ -64,4 +64,4 @@ transforms to:
     int *p = nullptr;
   }
 
-if the :option:`UserNullMacros` option is set to ``MY_NULL``.
+if the :option:`NullMacros` option is set to ``MY_NULL``.


### PR DESCRIPTION
According to [this line](https://github.com/llvm-mirror/clang-tools-extra/blob/2cd835ee5bcd6c4944d7e30826668ec38db40b38/clang-tidy/modernize/UseNullptrCheck.cpp#L466), the option is actually called `NullMacros` and not `UserNullMacros`.